### PR TITLE
Add ability to restore fullscreen windows to electron-window-plus

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -70,6 +70,9 @@ windowPlus.restore = function (defaultUrl, opts) {
         let opts2 = Object.assign({}, opts);
         opts2.show = false;
 
+        if ( state.fullscreen ) {
+          opts2.fullscreen = true;
+        }
         win = new BrowserWindow(opts2);
         _mainwin = win;
       } else {
@@ -503,6 +506,7 @@ function _saveWindowStates () {
       url: winInfo.url || win.webContents.getURL(),
       argv: winInfo.argv,
       userdata: winInfo.userdata,
+      fullscreen: win === _mainwin ? win.isFullScreen() : false,
 
       // win states
       main: win === _mainwin,


### PR DESCRIPTION
Hey Johnny -- 

I noticed that if you use `electron-window-plus` with fullscreen windows, if you try to restore them, it won't restore them in fullscreen. 

So, I added fullscreen attribute tracking that will restore the main window to fullscreen if the main window is in fullscreen when the app is closed. 

Let me know if this can be added, or if you have any questions :)! 

Eric