### PR TITLE
Add did-navigate-in-page listener to update the url property of each window

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -183,6 +183,13 @@ windowPlus.manage = function (win, uuid, userdata) {
     }
   });
 
+  win.webContents.on('did-navigate-in-page', (event, url) => {
+    let info = _getWinInfo(win.id);
+    if ( info ) {
+      info.url = url;
+    }
+  });
+
   emitter.emit('manage', win);
 };
 


### PR DESCRIPTION
Hey Johnny -- 

I noticed an issue where, because I have a single-page app and could not use `windowPlus.loadURL()` everytime I navigated, when I restored windows, the urls of those windows would not be current.

I did some digging, and found that it was because, in navigating via clicking links in-page, the `url` property of the window was not updating. 

So, to fix this, I added a listener for `did-navigate-in-page` that updates the windowInfo's `url` property. Now after in-page navigation happens,  the `url` property will update correctly for the window.

Let me know if you'd consider adding this in and if you have any additional questions. Thanks! 

 Eric